### PR TITLE
changed to mapTo, mapToAsync, continueWith

### DIFF
--- a/example/safe_result_example.dart
+++ b/example/safe_result_example.dart
@@ -62,15 +62,11 @@ void main() async {
 
 Future<Result<User>> login(String email, String password) async {
   return validateEmail(email)
-      .runAfter(after: (_) => validatePassword(password))
-      .runAfterAsync(
-        after: (_) {
-          return Result.safeRunAsync(
-            () async => getAccessToken(email, password),
-          );
-        },
-      )
-      .runAfterAsync(after: getUser);
+      .mapTo((_) => validatePassword(password))
+      .continueWith((_) {
+        return Result.safeRunAsync(() async => getAccessToken(email, password));
+      })
+      .continueWith(getUser);
 }
 
 Result<void> validateEmail(String email) {

--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -2,6 +2,8 @@ import 'package:safe_result/src/error.dart';
 
 typedef FutureResult<T> = Future<Result<T>>;
 typedef ResultStream<T> = Stream<Result<T>>;
+typedef ResultMapperCallback<R, T> = Result<R> Function(T data);
+typedef ResultMapperCallbackAsync<R, T> = FutureResult<R> Function(T data);
 
 abstract class Result<T> {
   Result._();
@@ -89,7 +91,7 @@ abstract class Result<T> {
     return tryGetData() ?? defaultValue;
   }
 
-  Result<R> runAfter<R>({required Result<R> Function(T data) after}) {
+  Result<R> mapTo<R>(ResultMapperCallback<R, T> after) {
     try {
       if (isError) return Result.error((this as ResultWithError<T>).error);
       final data = (this as ResultWithData<T>).data;
@@ -101,9 +103,7 @@ abstract class Result<T> {
     }
   }
 
-  FutureResult<R> runAfterAsync<R>({
-    required FutureResult<R> Function(T data) after,
-  }) async {
+  FutureResult<R> continueWith<R>(ResultMapperCallbackAsync<R, T> after) async {
     try {
       if (isError) return Result.error((this as ResultWithError<T>).error);
       final data = (this as ResultWithData<T>).data;
@@ -127,9 +127,7 @@ class ResultWithError<T> extends Result<T> {
 }
 
 extension FutureResultRunAfter<T> on FutureResult<T> {
-  FutureResult<R> runAfter<R>({
-    required Result<R> Function(T data) after,
-  }) async {
+  FutureResult<R> mapToAsync<R>(ResultMapperCallback<R, T> after) async {
     try {
       final current = await this;
       if (current.isError) {
@@ -144,9 +142,7 @@ extension FutureResultRunAfter<T> on FutureResult<T> {
     }
   }
 
-  FutureResult<R> runAfterAsync<R>({
-    required FutureResult<R> Function(T data) after,
-  }) async {
+  FutureResult<R> continueWith<R>(ResultMapperCallbackAsync<R, T> after) async {
     try {
       final current = await this;
       if (current.isError) {

--- a/test/result_test.dart
+++ b/test/result_test.dart
@@ -37,27 +37,21 @@ void main() {
       () {
         final sequence = <int>[];
         final result = returnsSuccess(1)
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsSuccess(next);
-              },
-            )
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsSuccess(next);
-              },
-            )
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsSuccess(next);
-              },
-            );
+            .mapTo((data) {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsSuccess(next);
+            })
+            .mapTo((data) {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsSuccess(next);
+            })
+            .mapTo((data) {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsSuccess(next);
+            });
 
         expect(result.isSuccess, true);
         expect(result.tryGetData(), 4);
@@ -66,31 +60,25 @@ void main() {
     );
 
     test(
-      'should execute sequential asynchronous runAfterAsync calls successfully',
+      'should execute sequential asynchronous after calls successfully',
       () async {
         final sequence = <int>[];
         final result = await returnsSuccess(1)
-            .runAfterAsync(
-              after: (data) async {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsFutureSuccess(next);
-              },
-            )
-            .runAfterAsync(
-              after: (data) async {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsFutureSuccess(next);
-              },
-            )
-            .runAfterAsync(
-              after: (data) async {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsFutureSuccess(next);
-              },
-            );
+            .continueWith((data) async {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsFutureSuccess(next);
+            })
+            .continueWith((data) async {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsFutureSuccess(next);
+            })
+            .continueWith((data) async {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsFutureSuccess(next);
+            });
 
         expect(result.isSuccess, true);
         expect(result.tryGetData(), 4);
@@ -103,27 +91,21 @@ void main() {
       () async {
         final sequence = <int>[];
         final result = await returnsFutureSuccess(1)
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsSuccess(next);
-              },
-            )
-            .runAfterAsync(
-              after: (data) async {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsFutureSuccess(next);
-              },
-            )
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsSuccess(next);
-              },
-            );
+            .mapToAsync((data) {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsSuccess(next);
+            })
+            .continueWith((data) async {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsFutureSuccess(next);
+            })
+            .mapToAsync((data) {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsSuccess(next);
+            });
 
         expect(result.isSuccess, true);
         expect(result.tryGetData(), 4);
@@ -139,20 +121,16 @@ void main() {
         final sequence = <int>[];
 
         var resultSync = returnsSuccess(1)
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsError(next);
-              },
-            )
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(99);
-                return returnsSuccess(next);
-              },
-            );
+            .mapTo((data) {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsError(next);
+            })
+            .mapTo((data) {
+              final next = data + 1;
+              sequence.add(99);
+              return returnsSuccess(next);
+            });
 
         expect(
           resultSync.isError,
@@ -182,27 +160,21 @@ void main() {
 
         sequence.clear();
         resultSync = returnsSuccess(1)
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsSuccess(next);
-              },
-            )
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsError(next);
-              },
-            )
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(99);
-                return returnsSuccess(next);
-              },
-            );
+            .mapTo((data) {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsSuccess(next);
+            })
+            .mapTo((data) {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsError(next);
+            })
+            .mapTo((data) {
+              final next = data + 1;
+              sequence.add(99);
+              return returnsSuccess(next);
+            });
 
         expect(
           resultSync.isError,
@@ -232,27 +204,21 @@ void main() {
 
         sequence.clear();
         final resultMixed = await returnsFutureSuccess(1)
-            .runAfterAsync(
-              after: (data) async {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsFutureSuccess(next);
-              },
-            )
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsError(next);
-              },
-            )
-            .runAfterAsync(
-              after: (data) async {
-                final next = data + 1;
-                sequence.add(99);
-                return returnsFutureSuccess(next);
-              },
-            );
+            .continueWith((data) async {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsFutureSuccess(next);
+            })
+            .mapToAsync((data) {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsError(next);
+            })
+            .continueWith((data) async {
+              final next = data + 1;
+              sequence.add(99);
+              return returnsFutureSuccess(next);
+            });
 
         expect(
           resultMixed.isError,
@@ -290,20 +256,16 @@ void main() {
         final sequence = <int>[];
 
         var resultSync = returnsSuccess(1)
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(next);
-                return throwsException(next);
-              },
-            )
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(99);
-                return returnsSuccess(next);
-              },
-            );
+            .mapTo((data) {
+              final next = data + 1;
+              sequence.add(next);
+              return throwsException(next);
+            })
+            .mapTo((data) {
+              final next = data + 1;
+              sequence.add(99);
+              return returnsSuccess(next);
+            });
 
         expect(
           resultSync.isError,
@@ -338,27 +300,21 @@ void main() {
 
         sequence.clear();
         resultSync = returnsSuccess(1)
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsSuccess(next);
-              },
-            )
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(next);
-                return throwsException(next);
-              },
-            )
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(99);
-                return returnsSuccess(next);
-              },
-            );
+            .mapTo((data) {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsSuccess(next);
+            })
+            .mapTo((data) {
+              final next = data + 1;
+              sequence.add(next);
+              return throwsException(next);
+            })
+            .mapTo((data) {
+              final next = data + 1;
+              sequence.add(99);
+              return returnsSuccess(next);
+            });
 
         expect(
           resultSync.isError,
@@ -393,27 +349,21 @@ void main() {
 
         sequence.clear();
         final resultMixed = await returnsFutureSuccess(1)
-            .runAfterAsync(
-              after: (data) async {
-                final next = data + 1;
-                sequence.add(next);
-                return returnsFutureSuccess(next);
-              },
-            )
-            .runAfter(
-              after: (data) {
-                final next = data + 1;
-                sequence.add(next);
-                return throwsException(next);
-              },
-            )
-            .runAfterAsync(
-              after: (data) async {
-                final next = data + 1;
-                sequence.add(99);
-                return returnsFutureSuccess(next);
-              },
-            );
+            .continueWith((data) async {
+              final next = data + 1;
+              sequence.add(next);
+              return returnsFutureSuccess(next);
+            })
+            .mapToAsync((data) {
+              final next = data + 1;
+              sequence.add(next);
+              return throwsException(next);
+            })
+            .continueWith((data) async {
+              final next = data + 1;
+              sequence.add(99);
+              return returnsFutureSuccess(next);
+            });
 
         expect(
           resultMixed.isError,
@@ -455,27 +405,21 @@ void main() {
       final sequenceOfDataPassed = <dynamic>[];
 
       final result = returnsStringSuccess('start')
-          .runAfter<int>(
-            after: (data) {
-              sequenceOfDataPassed.add(data);
-              final nextVal = data.length;
-              return returnsSuccess(nextVal);
-            },
-          )
-          .runAfter<String>(
-            after: (data) {
-              sequenceOfDataPassed.add(data);
-              final nextVal = data.toString();
-              return returnsStringSuccess(nextVal);
-            },
-          )
-          .runAfter<bool>(
-            after: (data) {
-              sequenceOfDataPassed.add(data);
-              final nextVal = data.isNotEmpty;
-              return Result.success(nextVal);
-            },
-          );
+          .mapTo<int>((data) {
+            sequenceOfDataPassed.add(data);
+            final nextVal = data.length;
+            return returnsSuccess(nextVal);
+          })
+          .mapTo<String>((data) {
+            sequenceOfDataPassed.add(data);
+            final nextVal = data.toString();
+            return returnsStringSuccess(nextVal);
+          })
+          .mapTo<bool>((data) {
+            sequenceOfDataPassed.add(data);
+            final nextVal = data.isNotEmpty;
+            return Result.success(nextVal);
+          });
 
       expect(sequenceOfDataPassed, ['start', 5, '5']);
 


### PR DESCRIPTION
- updated runAfterto mapTo since it makes sense, we are mapping a result another result to 
- updated runAfter for future result type to mapToAsync since it is async but the mapping is sync
- updated runAfterAsync to continueWith which indicates that it will only continue after the async call 